### PR TITLE
Enhance OpenAI Compatible model

### DIFF
--- a/gepetto/config.py
+++ b/gepetto/config.py
@@ -70,8 +70,12 @@ def get_config(section, option, environment_variable=None, default=None):
     try:
         if parsed_ini and parsed_ini.get(section, option):
             return parsed_ini.get(section, option)
-        if environment_variable and os.environ.get(environment_variable):
-            return os.environ.get(environment_variable)
+        if environment_variable is not None:
+            if isinstance(environment_variable, (str)):
+                environment_variable = [environment_variable]
+            for env_var in environment_variable:
+                if os.environ.get(env_var):
+                    return os.environ.get(env_var)
     except (configparser.NoSectionError, configparser.NoOptionError):
         print(_("Warning: Gepetto's configuration doesn't contain option {option} in section {section}!").format(
             option=option,


### PR DESCRIPTION
I want to be able to use other types of models that OpenAI offers without
modifying the `openai.py` client -- which hardcodes its models.

This diff makes this possible by the following changes:

- Updated `is_configured_properly()` method to check for the OpenAI API key in
environment variables when not found in the config.
- Added a check to ensure that we do not leak the OPENAI_API_KEY to the upstream
openai compatible provider, while checking that we're using the OpenAPI API key
with a compatible model only when accompanying it with an explicit base url to
OpenAI's API url.
- Modified `get_config()` to let us retrieve values from a list of strings while
maintaining backward compatibility with previous releases.